### PR TITLE
Фикс шаблона для правильной работы Ответить

### DIFF
--- a/templates/skin/developer-jquery/comment_tree.tpl
+++ b/templates/skin/developer-jquery/comment_tree.tpl
@@ -17,8 +17,9 @@
 	{foreach from=$aComments item=oComment name=rublist}
 		{assign var="cmtlevel" value=$oComment->getLevel()}
 		
-		{if $cmtlevel>$oConfig->GetValue('module.comment.max_tree')}
+		{if $cmtlevel>=$oConfig->GetValue('module.comment.max_tree')}
 			{assign var="cmtlevel" value=$oConfig->GetValue('module.comment.max_tree')}
+			{assign var="bAllowNewComment" value="false"}
 		{/if}
 		
 		{if $nesting < $cmtlevel} 

--- a/templates/skin/developer/comment_tree.tpl
+++ b/templates/skin/developer/comment_tree.tpl
@@ -37,8 +37,9 @@
 	{assign var="nesting" value="-1"}
 	{foreach from=$aComments item=oComment name=rublist}
 		{assign var="cmtlevel" value=$oComment->getLevel()}
-		{if $cmtlevel>$oConfig->GetValue('module.comment.max_tree')}
+		{if $cmtlevel>=$oConfig->GetValue('module.comment.max_tree')}
 			{assign var="cmtlevel" value=$oConfig->GetValue('module.comment.max_tree')}
+			{assign var="bAllowNewComment" value="false"}
 		{/if}
 		{if $nesting < $cmtlevel}        
 		{elseif $nesting > $cmtlevel}    	

--- a/templates/skin/new-jquery/comment_tree.tpl
+++ b/templates/skin/new-jquery/comment_tree.tpl
@@ -24,8 +24,9 @@
 	{foreach from=$aComments item=oComment name=rublist}
 		{assign var="cmtlevel" value=$oComment->getLevel()}
 		
-		{if $cmtlevel>$oConfig->GetValue('module.comment.max_tree')}
+		{if $cmtlevel>=$oConfig->GetValue('module.comment.max_tree')}
 			{assign var="cmtlevel" value=$oConfig->GetValue('module.comment.max_tree')}
+			{assign var="bAllowNewComment" value="false"}
 		{/if}
 		
 		{if $nesting < $cmtlevel} 

--- a/templates/skin/new/comment_tree.tpl
+++ b/templates/skin/new/comment_tree.tpl
@@ -44,8 +44,9 @@
 				{assign var="nesting" value="-1"}
 				{foreach from=$aComments item=oComment name=rublist}
 					{assign var="cmtlevel" value=$oComment->getLevel()}
-					{if $cmtlevel>$oConfig->GetValue('module.comment.max_tree')}
+					{if $cmtlevel>=$oConfig->GetValue('module.comment.max_tree')}
 						{assign var="cmtlevel" value=$oConfig->GetValue('module.comment.max_tree')}
+						{assign var="bAllowNewComment" value="false"}
 					{/if}
    					{if $nesting < $cmtlevel}        
     				{elseif $nesting > $cmtlevel}    	


### PR DESCRIPTION
При указание в конфиге
$config['module']['comment']['max_tree'] = 7; // Максимальная вложенность комментов при отображении

Ограничение не работает должным образом и позволяет создавать комментарии с бесконечным уровнем вложенности. 

Данным изменением мы убираем кнопку ответить у тех комментариев чей уровень соответствует максимальному.

Но тем не менее это решает проблему лишь на половину. Требуется проверка в js. 
