### PR TITLE
На старых системах (FreeBSD 6.1) наблюдается проблема в метатегах - отде...

### DIFF
--- a/engine/include/function.php
+++ b/engine/include/function.php
@@ -280,7 +280,7 @@ function func_text_words($sText,$iCountWords) {
 		
 	$iCount=0;
 	$aWordsResult=array();
-	$aWords=preg_split("/\s+/",$sText);	
+	$aWords=preg_split("/\s+/u",$sText);	
 	for($i=0;$i<count($aWords);$i++) {
 		if ($iCount>=$iCountWords) {
 			break;


### PR DESCRIPTION
На старых системах (FreeBSD 6.1) наблюдается проблема в метатегах - отдельные кириллические символы (х, я, Р и т. д.) отображаются некорректно. Например: "случайно обнаружил на простора� сети сайт курски� эникейщиков".

Для решения этой проблемы нужно добавить модификатор u в файл /engine/include/function.php строка 285
$aWords=preg_split("/\s+/",$sText); меняем на $aWords=preg_split("/\s+/u",$sText);
