### PR TITLE
Добавлен стиль подсветки искомых фраз при поиске. 

### DIFF
--- a/templates/skin/new-jquery/css/common.css
+++ b/templates/skin/new-jquery/css/common.css
@@ -115,3 +115,5 @@ table.table-talk a.favourite:hover { background-position: -50px -40px; }
 span.green { color: #008000; }
 
 img.tagcloud { border: 0; margin-left: 13px; }
+
+.searched-item { background: #fffacd; }


### PR DESCRIPTION
В шаблоне new стиль был, а в new-jquery его перенести забыли, теперь фразы не подсвечиваются, можно посмотреть прямо на сайте livestreet.ru
