### PR TITLE
SH скрипт для выдачи прав перед установкой

### DIFF
--- a/install/build.sh
+++ b/install/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+ABSOLUTE_FILENAME=`readlink -e "$0"`
+DIRECTORY=`dirname "$ABSOLUTE_FILENAME"`
+
+if [ ! -e "$DIRECTORY/../config/config.local.php" ]; then
+    cp $DIRECTORY/../config/config.local.dist.php $DIRECTORY/../config/config.local.php
+fi
+
+chmod 777 $DIRECTORY/../config/config.local.php
+chmod 777 $DIRECTORY/../tmp
+chmod 777 $DIRECTORY/../logs
+chmod 777 $DIRECTORY/../uploads
+chmod 777 $DIRECTORY/../templates/compiled
+chmod 777 $DIRECTORY/../templates/cache
+chmod 777 $DIRECTORY/../plugins


### PR DESCRIPTION
Перед установкой LiveStreet необходимо удовлетворить следующие требования:
Файл config.local.php существует и доступен для записи
Директория /tmp существует  и доступна для записи 
Директория /logs существует и доступна для записи
Директория /uploads существует и доступна для записи
Директория /templates/compiled существует и доступна для записи
Директория /templates/cache существует и доступна для записи
Директория /plugins существует и доступна для записи

Часто это бывает достаточно рутинной задачей. Теперь мы можем просто запустить скрипт перед установкой следующей командой: 

sudo sh /var/www/livestreet/install/build.sh

Затем установить движок и удалить папку install вместе со скриптом.
