### PR TITLE
Получение тэгов топиков, для всех типов блогов кроме закрытых.

### DIFF
--- a/classes/modules/topic/mapper/Topic.mapper.class.php
+++ b/classes/modules/topic/mapper/Topic.mapper.class.php
@@ -335,7 +335,7 @@ class ModuleTopic_MapperTopic extends Mapper {
 				AND
 				tt.blog_id = b.blog_id
 				AND
-				b.blog_type IN ('open','personal')
+				b.blog_type <> 'close'
 			GROUP BY 
 				tt.topic_tag_text
 			ORDER BY 


### PR DESCRIPTION
Если добавить новый тип блога то тэги его топиков не будут появляться в общей выдаче. В частности для плагина Компании приходится перекрывать выборку.
