### PR TITLE
Возможность версионирования CSS для сброса кэша браузера.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -549,6 +549,13 @@ $config['compress']['css']['optimise_shorthands'] = 1;
 $config['compress']['css']['remove_last_;']       = true;
 $config['compress']['css']['css_level']           = 'CSS2.1';
 $config['compress']['css']['template']            = "highest_compression";
+/*
+ * Версия файла CSS. Может использоваться для принудительного обновления закэшированного в браузере
+ * файла. Вынесите этот параметр в config.local.php и увиличивайте его на единицу, каждый раз
+ * когда хотите чтобы барузеры всех ваших посетителей обязательно перечитали стили.
+ * Подробнее см. http://speedupyourwebsite.ru/books/reactive-websites/
+ */
+$config['compress']['css']['version']             = 0;
 /**
  * Параметры компрессии js-файлов
  */

--- a/engine/modules/viewer/Viewer.class.php
+++ b/engine/modules/viewer/Viewer.class.php
@@ -1223,8 +1223,10 @@ class ModuleViewer extends Module {
 	protected function BuildHtmlHeadFiles($aFileList) {
 		$aHeader=array('js'=>'','css'=>'');
 
+		$sCssVersion = ($v = Config::Get('compress.css.version')) ? '?v=' . $v : '';
+
 		foreach ((array)$aFileList['css'] as $sCss) {
-			$aHeader['css'].=$this->WrapHtmlHack("<link rel='stylesheet' type='text/css' href='{$sCss}' />", $sCss, 'css').PHP_EOL;
+			$aHeader['css'].=$this->WrapHtmlHack("<link rel='stylesheet' type='text/css' href='{$sCss}{$sCssVersion}' />", $sCss, 'css').PHP_EOL;
 		}
 		foreach((array)$aFileList['js'] as $sJs) {
 			$aHeader['js'].=$this->WrapHtmlHack("<script type='text/javascript' src='{$sJs}'></script>",$sJs,'js').PHP_EOL;


### PR DESCRIPTION
Распространённой практикой увеличения скорости загрузки сайта, является установка для статических файлов заголовка Expires в далёкое будущее. Обратной стороной медали является проблема принудительной загрузки таких файлов в случае их изменения. Подробно это описано здесь: http://cap-design.ru/rw/1-4-5.htm

Предлагаемый патч добавляет в LS возможность версионирования скомпилированного файла CSS.

Для этого в настройки вводится параметр «compress.css.version», задающий версию, которая будет добавлена в качестве аргумента GET к адресу файла CSS.
