### PR TITLE
Add update topic content function

### DIFF
--- a/classes/modules/topic/Topic.class.php
+++ b/classes/modules/topic/Topic.class.php
@@ -1857,5 +1857,20 @@ class ModuleTopic extends Module {
 	public function GetTopicItemsByArrayId($aTopocId) {
 		return $this->GetTopicsByArrayId($aTopocId);
 	}
+
+    /**
+     * Обновление данных напрямую в таблице topic_content
+     *
+     * @param ModuleTopic_EntityTopic $oTopic
+     *
+     * @return bool result
+     */
+    public function UpdateTopicContent($oTopic)
+    {
+        $this->Cache_Clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG,array('topic_update',"topic_update_user_{$oTopic->getUserId()}"));
+        $this->Cache_Delete("topic_{$oTopic->getId()}");
+
+        return $this->oMapperTopic->UpdateContent($oTopic);
+    }
 }
 ?>


### PR DESCRIPTION
Бывает необходимость добавить значения  скажем в поле topic_extra. которое находится в таблице topic_content, но если кроме этого поля в  сущности топика больше ничего не менялось  то  проверка 
if ($res!==false and !is_null($res)) {
    $this->UpdateTopicContent($oTopic);
    return true;
}

в функции oMapper->UpdateTopic
может не сработать,  и значение не обновится, 
поэтому предлагаю добавить соответствующую функцию
