### PR TITLE
Фикс отстутствие тегов избранного, если юзер не добавил ни одного своего тега

### DIFF
--- a/application/classes/modules/favourite/Favourite.class.php
+++ b/application/classes/modules/favourite/Favourite.class.php
@@ -339,7 +339,7 @@ class ModuleFavourite extends Module {
 		/**
 		 * Добавляем новые
 		 */
-		if ($bAddNew and $oFavourite->getTags()) {
+		if ($bAddNew) {
 			/**
 			 * Добавляем теги объекта избранного, если есть
 			 */
@@ -351,14 +351,17 @@ class ModuleFavourite extends Module {
 					$this->oMapper->AddTag($oTag);
 				}
 			}
-			/**
-			 * Добавляем пользовательские теги
-			 */
-			foreach($oFavourite->getTagsArray() as $sTag) {
-				$oTag=Engine::GetEntity('ModuleFavourite_EntityTag',$oFavourite->_getData());
-				$oTag->setText($sTag); // htmlspecialchars уже используется при установке тегов
-				$oTag->setIsUser(1);
-				$this->oMapper->AddTag($oTag);
+			if ($oFavourite->getTags()) {
+				/**
+				 * Добавляем пользовательские теги
+				 */
+				$aTags = $oFavourite->getTagsArray();
+				foreach ($aTags as $sTag) {
+					$oTag = Engine::GetEntity('ModuleFavourite_EntityTag', $oFavourite->_getData());
+					$oTag->setText($sTag); // htmlspecialchars уже используется при установке тегов
+					$oTag->setIsUser(1);
+					$this->oMapper->AddTag($oTag);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Для https://github.com/livestreet/livestreet/issues/332

При создании или редактировании избранного элемента, удаляются, а затем заново добавляются теги к этому элементу. Но условие добавления было таким, что если не передаются пользовательские теги, то не добавляются и уже существующие. Сделал так, чтобы существующие добавлялись всегда, а пользовательские, если есть.

Аналог реквеста https://github.com/livestreet/livestreet/pull/345, но не разобрался с git тогда.
