### PR TITLE
Фикс превью топика

### DIFF
--- a/application/frontend/components/topic/topic.tpl
+++ b/application/frontend/components/topic/topic.tpl
@@ -86,7 +86,7 @@
         {$previewImage = $topic->getPreviewImageWebPath('900x300crop')}
 
         {if $previewImage}
-            <div class="topic-preview-image">
+            <div class="ls-topic-preview-image">
                 <img src="{$previewImage}" />
             </div>
         {/if}


### PR DESCRIPTION
Отсутствовал селектор, из-за этого на маленьком разрешении превью отображалось не верно.