### PR TITLE
Фикс аякс фильтра

### DIFF
--- a/application/frontend/components/search-ajax/js/search-ajax.js
+++ b/application/frontend/components/search-ajax/js/search-ajax.js
@@ -219,7 +219,7 @@
                 this.elements.list.hide();
             }
 
-            if ( this.option( 'i18n.title' ) && this.elements.title.length ) {
+            if ( this.option( 'i18n.title' ) && this.elements.title.length && response.searchCount) {
                 this.elements.title.show().text( this._i18n( 'title', response.searchCount ) );
             }
 


### PR DESCRIPTION
Если ничего не находило, т.е. 0 элементов, выводило в заголовке "Найден %%count%% блог;Найдено %%count%% блога;Найдено %%count%% блогов".