### PR TITLE
Убрана подгрузка данных YaShare в списке

### DIFF
--- a/application/frontend/components/topic/topic.tpl
+++ b/application/frontend/components/topic/topic.tpl
@@ -204,7 +204,7 @@
         </footer>
 
         {* Всплывающий блок появляющийся при нажатии на кнопку Поделиться *}
-        {if ! $isPreview}
+        {if ! $isList && ! $isPreview}
             <div class="ls-tooltip" id="topic_share_{$topic->getId()}">
                 <div class="ls-tooltip-content js-ls-tooltip-content">
                     {hookb run="topic_share" topic=$topic isList=$isList}


### PR DESCRIPTION
Кнопка поделиться не отображается в списке топиков, но данные подгружались, что существенно влияло на окончательную прогрузку страницы.