### PR TITLE
Requirements PHP >= 5.4

### DIFF
--- a/application/install/backend/step/checkRequirements.php
+++ b/application/install/backend/step/checkRequirements.php
@@ -10,7 +10,7 @@ class InstallStepCheckRequirements extends InstallStep
          */
         $sAdditionalSolution = '';
         $aRequirements = array();
-        if (!version_compare(PHP_VERSION, '5.3.2', '>=')) {
+        if (!version_compare(PHP_VERSION, '5.4', '>=')) {
             $aRequirements[] = array(
                 'name'    => 'php_version',
                 'current' => PHP_VERSION


### PR DESCRIPTION
В 5.3.2 ругается на отсутствие функции **session_status**.

Недавно столкнулся на клиенте.
Заткнул костылем в **Session.class.php**, но лучше и проще наверное поднять планку.

### Сам костыль:
```
/**
 *
 * Returns the session status.
 *
 * Nota bene:
 *
 * PHP 5.3 implementation of session_status() for only active/none.
 * Relies on the fact that ini setting 'session.use_trans_sid' cannot be
 * changed when a session is active.
 *
 * PHP ini_set() raises a warning when we attempt to change this setting
 * and session is active. Note that the attempted change is to the
 * pre-existing value, so nothing will actually change on success.
 *
 */
 protected function sessionStatus()
 {
    $setting = 'session.use_trans_sid';
    $current = ini_get($setting);
    $result  = ini_set($setting, $current);
    return $result !== $current;
}
```
и
```
if ((function_exists('session_status') && session_status() === PHP_SESSION_ACTIVE) || $this->sessionStatus()) {
```
вместо
```
if (session_status() == PHP_SESSION_ACTIVE) {
```