### PR TITLE
fix #809

### DIFF
--- a/application/frontend/components/property/input/property.date.tpl
+++ b/application/frontend/components/property/input/property.date.tpl
@@ -3,17 +3,18 @@
     {$_mods='inline'}
 {/if}
 {component 'field.date' mods = $_mods
-    name         = "property[{$property->getId()}][date]"
-    inputAttributes=[ "data-lsdate-format" => 'DD.MM.YYYY' ]
-    inputClasses = "js-field-date-default"
-    value        = $property->getValue()->getValueForForm()
-    note         = $property->getDescription()
-    label        = $property->getTitle()}
+    name            = "property[{$property->getId()}][date]"
+    inputAttributes = [ "data-lsdate-format" => 'DD.MM.YYYY' ]
+    inputClasses    = "js-field-date-default"
+    value           = $property->getValue()->getValueForForm()
+    note            = $property->getDescription()
+    label           = $property->getTitle()}
 
 {if $property->getParam('use_time')}
     {component 'field.time' mods = $_mods
-        name         = "property[{$property->getId()}][time]"
-        inputAttributes=[ "data-lstime-time-format" => 'H:i' ]
-        inputClasses = "js-field-time-default"
-        value        = $property->getValue()->getValueTypeObject()->getValueTimeForForm()}
+        name            = "property[{$property->getId()}][time]"
+        inputAttributes = [ "data-lstime-time-format" => 'H:i' ]
+        inputClasses    = "js-field-time-default"
+        value           = $property->getValue()->getValueTypeObject()->getValueTimeForForm()
+        note            = ($property->getDescription()) ? '&nbsp;' : ''}
 {/if}


### PR DESCRIPTION
Еще нужно убрать `verical-align-top;` в классе **ls-field--inline** https://github.com/livestreet/livestreet-framework/commit/c4144ae3a4ae1d7e2ebe44c78c246ef7a4b4c5b0

При вертикальном выравнивании по верху, много возни с label и его авто-двоеточиями.
И при таком подходе у меня не съехало ни одной моей кастомной формы.

Получил следующее: https://yadi.sk/i/umlVxB0J3B5HFu
