### PR TITLE
Постраничность комментариев

### DIFF
--- a/application/classes/hooks/HookMain.class.php
+++ b/application/classes/hooks/HookMain.class.php
@@ -77,6 +77,7 @@ class HookMain extends Hook
                 'recaptcha.site_key'    => Config::Get('module.validate.recaptcha.site_key'),
                 'comment_max_tree'      => Config::Get('module.comment.max_tree'),
                 'comment_show_form'     => Config::Get('module.comment.show_form'),
+                'comment_use_paging'    => Config::Get('module.comment.use_nested'),
                 'topic_max_blog_count'  => Config::Get('module.topic.max_blog_count'),
                 'block_stream_show_tip' => Config::Get('block.stream.show_tip'),
                 'poll_max_answers'      => Config::Get('module.poll.max_answers'),

--- a/application/frontend/components/comment/js/comments.js
+++ b/application/frontend/components/comment/js/comments.js
@@ -57,6 +57,8 @@
             folding: true,
             // Показать/скрыть форму по умолчанию
             show_form: false,
+            // Включена или нет пагинация
+            use_paging: false,
             // Ajax параметры
             params: {},
             i18n: {
@@ -171,7 +173,7 @@
                 target_type: this._targetType,
                 last_comment_id: this.getLastCommentId(),
                 self_comment_id: commentSelfId || undefined,
-                use_paging: false
+                use_paging: this.option( 'use_paging' )
             };
 
             this._load( 'load', params, function( response ) {

--- a/application/frontend/skin/developer/assets/js/init.js
+++ b/application/frontend/skin/developer/assets/js/init.js
@@ -596,7 +596,8 @@ jQuery(document).ready(function($){
             add:  aRouter['blog'] + 'ajaxaddcomment/',
             load: aRouter['blog'] + 'ajaxresponsecomment/'
         },
-        show_form: ls.registry.get('comment_show_form')
+        show_form:  ls.registry.get('comment_show_form'),
+        use_paging: ls.registry.get('comment_use_paging')
     });
 
     // Кнопка обновления комментариев

--- a/application/frontend/skin/synio/assets/js/init.js
+++ b/application/frontend/skin/synio/assets/js/init.js
@@ -589,6 +589,7 @@ jQuery(document).ready(function($){
             load: aRouter['blog'] + 'ajaxresponsecomment/'
         },
         show_form: ls.registry.get('comment_show_form'),
+        use_paging: ls.registry.get('comment_use_paging'),
         loaded: function () {
             if (activityBlockRecent.length) {
                 activityBlockRecent.lsBlock('getElement', 'tabs').lsTabs('getActiveTab').lsTab('activate');


### PR DESCRIPTION
Фикс загрузки комментов со всех последующих страниц после текущей - откуда добавляется комментарий.

Еще ошибки:
1) вот тут реверс пагинации сейчас не имеет смысла (https://github.com/livestreet/livestreet/blob/master/application/classes/actions/ActionBlog.class.php#L837)
реверс нужно реализовать опцией в компоненте **Pagination**
и реверсировать желательно когда последние комменты на первой странице, тогда пусть будет 5 4 3 2 1 (правда тогда теряется смысл в этой опции в бэкенде (может и к лучшему?))
а когда на последние на последней то хочется видеть 1 2 3 4 5
2) при выключенном реверсе ( то есть последние комменты на последней странице ) - всё ок, только почему то на первой может отображаться 5 штук (при установленных 50) - ведет как положено себе вести последней странице.
3) при открытии страницы топика без параметра **cmtpage** пагинатор упорно не хочет выделять текущую страницу. Удалось вылечить убрав сравнение типов `isActive=( $smarty.section.pagination.index == $current )` , хотя **cmtpage** никак явно на тип переменной пагинации вроде не влияет... (с параметром всё ок показывает).
4) новый коммент добавляется на текущей странице (например на 2 из 5), после перезагрузки встает на место. Здесь явно нужна ajax пагинация, тогда и страницу можно будет переключить на нужную еще и новые комменты подгрузить как надо и вообще кнопку подгрузки вернуть в работу.
может еще и ветки разбить получится? а то ставлю 10 комментов на страницу, цепляет еще 2к+ дочерних, браузер плеваться начинает даже(
